### PR TITLE
add uuid support

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -22,8 +22,9 @@
     
         async init(peerId) {
             const { Peer } = await import('https://esm.sh/peerjs@1.5.4?bundle-deps');
+            const { v5: uuidv5 } = await import('https://esm.sh/uuid@10.0.0?bundle-deps');
     
-            this.#peerId = peerId;
+            this.#peerId = uuidv5(peerId, uuidv5.URL);
             this.#peer = new Peer();
     
             this.#peer.on('open', (id) => {


### PR DESCRIPTION
### Description

When using Oneline, there's no need to worry about the peer ID format. Since the goal is simply to display the number of online users on the website, you can easily pass a URL as the ID. This also lowers the barrier for user adoption.

### Linked Issues

Close #1